### PR TITLE
Change API key name from SECRET_KEY_BASE to heroku_api_key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - bundle exec rspec
 deploy:
   provider: heroku
-  api_key: $SECRET_KEY_BASE
+  api_key: heroku_api_key
   app: pawty-trainer-api
   run: rails db:migrate
   on: 


### PR DESCRIPTION
# Description
Troubleshooting Travis deploying from main to Heroku. We are establishing a new name for the Heroku api key: instead of SECRET_KEY_BASE found in `.travis.yml` said variable will now be `heroku_api_key`. Perhaps this will fix the issue.

Thank you
Fixes # (issue)

## Behavior
### Current behavior
Description:

### New behavior
Description:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
