### PR TITLE
Add gem sprockets lower version 3.7.2 instead of 4.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'figaro'
 gem 'json'
 gem 'jsonapi-serializer'
 gem 'graphql'
+gem 'sprockets', '~> 3.7.2'
+# gem 'sprockets'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
@@ -54,8 +56,6 @@ group :development do
 end
 
 group :test do
-  gem 'factory_bot_rails'
-  gem 'faker'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     bcrypt (3.1.16)
-    bootsnap (1.7.7)
+    bootsnap (1.8.0)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -205,7 +205,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    sprockets (4.0.2)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.2)
@@ -257,6 +257,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers
   simplecov
+  sprockets (~> 3.7.2)
   travis
   tzinfo-data
   vcr


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Fixes # (issue)

## Behavior
### Current behavior
Description: Not passing in Travis CI

### New behavior
Description: Lowered sprockets version to 3.7.2 per [google search Sprockets::FileNotFound: couldn't find file 'graphiql/rails/application.css'](https://linuxtut.com/en/6aa4b9175d2d00a44f4c/) error.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
