### PR TITLE
Add conditional statements for routes to bypass graphiql endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  if Rails.env.development?  
+  if Rails.env.development? || Rails.env.staging?
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: "graphql#execute"
   end
 


### PR DESCRIPTION
# Description
```
Rails.application.routes.draw do
  if Rails.env.development? || Rails.env.staging?
    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: "graphql#execute"
  end

  post "/graphql", to: "graphql#execute"
end
```

Please note that `|| Rails.env.staging?` was added in order to bypass Rails trying to match the nearest route match. We are attempting this solution in order to engage front end users with Heroku since they are currently unable to hit our API endpoints we created with graphql.

We did test our endpoints in both graphiql and postman. Locally we are golden. 

This leads us to believe our problem may reside with Heroku.
Fixes # (issue)

## Behavior
### Current behavior
Please see description.

### New behavior
Please see description.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
