### PR TITLE
Create update_dog and update_event files for GraphQL mutations

### DIFF
--- a/app/graphql/mutations/destroy_dog.rb
+++ b/app/graphql/mutations/destroy_dog.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class DestroyDog < BaseMutation
+    field :id, ID, null: true
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      dog = Dog.find(id)
+
+      dog.destroy
+      {
+        id: id,
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/destroy_event.rb
+++ b/app/graphql/mutations/destroy_event.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class DestroyEvent < BaseMutation
+    field :id, ID, null: true
+
+    argument :id, ID, required: true
+
+    def resolve(id:)
+      event = Event.find(id)
+
+      event.destroy
+      {
+        id: id,
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/update_dog.rb
+++ b/app/graphql/mutations/update_dog.rb
@@ -1,0 +1,20 @@
+class Mutations::UpdateDog < Mutations::BaseMutation
+    argument :id, ID, required: true
+    argument :name, String, required: false
+    argument :breed, String, required: false
+    argument :age, String, required: false
+
+    field :success, Boolean, null: false
+    field :errors, [String], null: false
+    field :dog, Types::DogType, null: true
+
+    def resolve(id:, **arguments)
+        dog = Dog.find(id)
+
+        if dog.update(arguments)
+            { success: true, dog: dog, errors: [] }
+        else
+            { success: false, event: nil, errors: record.errors.full_messages }
+        end
+    end
+end

--- a/app/graphql/mutations/update_event.rb
+++ b/app/graphql/mutations/update_event.rb
@@ -1,0 +1,20 @@
+class Mutations::UpdateEvent < Mutations::BaseMutation
+    argument :id, ID, required: true
+    argument :name, String, required: false
+    argument :completed, Boolean, required: false
+    argument :event_datetime, GraphQL::Types::ISO8601DateTime, required: false
+
+    field :success, Boolean, null: false
+    field :errors, [String], null: false
+    field :event, Types::EventType, null: true
+
+    def resolve(id:, **arguments)
+        event = Event.find(id)
+
+        if event.update(arguments)
+            { success: true, event: event, errors: [] }
+        else
+            { success: false, event: nil, errors: record.errors.full_messages }
+        end
+    end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,6 +3,8 @@ module Types
     field :create_user, mutation: Mutations::CreateUser
     field :create_dog, mutation: Mutations::CreateDog
     field :create_event, mutation: Mutations::CreateEvent
+    field :update_event, mutation: Mutations::UpdateEvent
+    field :update_dog, mutation: Mutations::UpdateDog
     # field :create_link, mutation: Mutations::CreateLink
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
+    field :destroy_dog, mutation: Mutations::DestroyDog
     field :create_user, mutation: Mutations::CreateUser
     field :create_dog, mutation: Mutations::CreateDog
     field :create_event, mutation: Mutations::CreateEvent

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
+    field :destroy_event, mutation: Mutations::DestroyEvent
     field :destroy_dog, mutation: Mutations::DestroyDog
     field :create_user, mutation: Mutations::CreateUser
     field :create_dog, mutation: Mutations::CreateDog

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -5,4 +5,5 @@ class Dog < ApplicationRecord
   validates :name, presence: true
   validates :age, presence: true, numericality: true
   validates :breed, presence: true
+  has_many :events, dependent: :destroy
 end


### PR DESCRIPTION
# Description
We can now update dog and update events.

`mutation_type.rb` had `update_dog` and `update_event` fields added. Relevant files were created for enabling graphQL to allow mutations for us. 

Destroy dog and event abilities are also created.

Fixes #29 #15 #30 

## Behavior
### Current behavior
Description:

### New behavior
Description:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
